### PR TITLE
feat: リンクボタンにZennアイコンを追加し、アイコンの型を拡張

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                 <span className="inline-block w-2 h-2 rounded-full bg-primary mr-2"></span>
                 Others
               </h2>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 {links.map((link) => (
                   <LinkButton key={link.name} link={link} />
                 ))}

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -22,13 +22,18 @@ export default function LinkButton({ link }: { link: LinkProps }) {
         rel="noopener noreferrer"
       >
         {link.icon ? (
+          typeof link.icon === 'string' ? (
             <Image
-                src={link.icon}
-                alt={link.name}
-                width={24}
-                height={24}
-                quality={100}
+              src={link.icon}
+              alt={link.name}
+              width={24}
+              height={24}
+              quality={100}
             />
+          ) : (
+            // Assuming link.icon is a ReactNode if not a string
+            <div className="w-6 h-6 flex items-center justify-center">{link.icon}</div>
+          )
         ) : (
           <div className="w-6 h-6" /> // Spacer for when icon is not present (24px)
         )}

--- a/data/portfolioData.tsx
+++ b/data/portfolioData.tsx
@@ -2,7 +2,7 @@ import { SectionProps, LinkProps } from '@/types/portfolio';
 import { WorkLinkItem } from '@/components/WorkLinkItem';
 import { FaPython, FaReact, FaGitAlt, FaDocker } from 'react-icons/fa';
 import { TbBrandGolang, TbBrandCpp, TbBrandTypescript, TbBrandNextjs } from 'react-icons/tb';
-import { SiC, SiPytorch, SiLangchain, SiLightning } from 'react-icons/si';
+import { SiC, SiPytorch, SiLangchain, SiLightning, SiZenn } from 'react-icons/si';
 
 export const sections: SectionProps[] = [
   {
@@ -75,4 +75,10 @@ export const links: LinkProps[] = [
     delay: 0.1,
     icon: "/signate_icon.svg"
     },
+  {
+    name: "Zenn",
+    url: "https://zenn.dev/cotora",
+    delay: 0.1,
+    icon: <SiZenn className="text-[#3EA8FF]" />
+  },
 ];

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -10,6 +10,6 @@ export interface SectionProps {
 export interface LinkProps {
   name: string;
   url: string;
+  icon?: string | ReactNode; // string (for Image src) or ReactNode
   delay: number;
-  icon?: string;
 }


### PR DESCRIPTION
closes #23 

- LinkButtonのiconにReactNodeを指定できるように修正